### PR TITLE
Fix python 3.7 generators

### DIFF
--- a/haystack/query.py
+++ b/haystack/query.py
@@ -147,12 +147,12 @@ class SearchQuerySet(object):
                 current_position += 1
 
             if self._cache_is_full():
-                raise StopIteration
+                return
 
             # We've run out of results and haven't hit our limit.
             # Fill more of the cache.
             if not self._fill_cache(current_position, current_position + ITERATOR_LOAD_PER_QUERY):
-                raise StopIteration
+                return
 
     def post_process_results(self, results):
         to_cache = []


### PR DESCRIPTION
`StopIteration` can now generate a `RuntimeError` in Python 3.7 per [PEP-479](https://www.python.org/dev/peps/pep-0479/). This change fixes the opportunity for that error to propagate by returning inside of the generator.